### PR TITLE
Bugfix for hosts protocol selection

### DIFF
--- a/src/Helpers/SearchParser.php
+++ b/src/Helpers/SearchParser.php
@@ -984,14 +984,20 @@
             $arr = Array();
             foreach($hosts as $host){
 
+                if( preg_match('/http:/', $host) ){
+                    $prot = "http";
+                }else{
+                    $prot = "https";
+                }
+
                 $host = str_replace( ['http:', 'https:', '//'], '', $host);
                 if(strpos($host, ':') === false){
 
-                    $arr[] = "http://$host:9200";
+                    $arr[] = "$prot://$host:9200";
 
                 } else {
 
-                    $arr[] = "http://$host";
+                    $arr[] = "$prot://$host";
 
                 }
 

--- a/www/example-composer.json
+++ b/www/example-composer.json
@@ -1,0 +1,14 @@
+  {
+    "repositories": [
+        {
+            "url": "https://github.com/MattyLabs/XMLadapter",
+            "type": "vcs"
+        }
+    ],
+    "require": {
+    
+	 	"mattylabs/xmladapter": "^1.0.0" 	 
+     
+    }
+}
+


### PR DESCRIPTION
hosts should be as specified, the script should be neutral and not impose https or http on the default settings passed. See SearchParser::check_hosts_port()